### PR TITLE
Added option 'unit_of_measurement' in sensor.py to draw history graph…

### DIFF
--- a/custom_components/bitfetch/sensor.py
+++ b/custom_components/bitfetch/sensor.py
@@ -98,6 +98,7 @@ class BitFetchSensor(Entity):
         attrs[ATTR_PAIR] = self._ticker.get("symbol")
         attrs[ATTR_LAST_UPDATED] = self._ticker.get("last_updated")
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
+        attrs["unit_of_measurement"] = self._ticker.get("symbol")
         return attrs
 
     def update(self):


### PR DESCRIPTION
Maybe base currency can be separated from 'symbol', I'm not sure. (examples: BTCUSD -> USD; ETHBTC -> BTC)
At this moment in this patch for "unit_of_measurement" used "symbol" (for example BTCUSD, ETHUSD, ETHBTC,...)
![image](https://user-images.githubusercontent.com/42122004/94991588-77489700-0584-11eb-8960-fef38c80ee8f.png)
